### PR TITLE
Fix notice warning "Undefined property: stdClass::$model"

### DIFF
--- a/libraries/whichbrowser.php
+++ b/libraries/whichbrowser.php
@@ -1921,7 +1921,7 @@
 					$this->device->identified = ID_PATTERN;
 				}
 
-				if ($this->device->model) {
+				if (!empty($this->device->model)) {
 					$device = DeviceModels::identify('palmos', $this->device->model);
 
 					if ($device->identified) {


### PR DESCRIPTION
User-agent "Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; PalmSource/hspr-H102; Blazer/4.0) 16;320x320" makes notice warning.